### PR TITLE
missing import time

### DIFF
--- a/clistats.go
+++ b/clistats.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync/atomic"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/projectdiscovery/freeport"


### PR DESCRIPTION
currently getting this error when trying to use version 0.0.13:
```
/go/pkg/mod/github.com/projectdiscovery/clistats@v0.0.13/clistats.go:134:17: undefined: time
/go/pkg/mod/github.com/projectdiscovery/clistats@v0.0.13/clistats.go:139:31: undefined: time
/go/pkg/mod/github.com/projectdiscovery/clistats@v0.0.13/clistats.go:140:17: undefined: time
```