### PR TITLE
fix: add ListenHost option so metrics can work on custom hosts

### DIFF
--- a/clistats.go
+++ b/clistats.go
@@ -172,14 +172,19 @@ func (s *Statistics) Start() error {
 	}
 
 	if s.Options.Web {
+		listenHost := s.Options.ListenHost
+		if listenHost == "" {
+			listenHost = DefaultOptions.ListenHost
+		}
+
 		mux := http.NewServeMux()
 		mux.HandleFunc("/metrics", s.metricsHandler)
 
 		// check if the default port is available
-		port, err := freeport.GetPort(freeport.TCP, "127.0.0.1", s.Options.ListenPort)
+		port, err := freeport.GetPort(freeport.TCP, listenHost, s.Options.ListenPort)
 		if err != nil {
 			// otherwise picks a random one and update the options
-			port, err = freeport.GetFreeTCPPort("127.0.0.1")
+			port, err = freeport.GetFreeTCPPort(listenHost)
 			if err != nil {
 				return err
 			}
@@ -244,7 +249,11 @@ func (s *Statistics) GetStatResponse(interval time.Duration, callback func(strin
 		return string(body), nil
 	}
 
-	url := fmt.Sprintf("http://127.0.0.1:%v/metrics", s.Options.ListenPort)
+	listenHost := s.Options.ListenHost
+	if listenHost == "" {
+		listenHost = DefaultOptions.ListenHost
+	}
+	url := fmt.Sprintf("http://%s:%v/metrics", listenHost, s.Options.ListenPort)
 	go func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()

--- a/options.go
+++ b/options.go
@@ -2,12 +2,14 @@ package clistats
 
 // DefaultOptions for clistats
 var DefaultOptions = Options{
+	ListenHost: "127.0.0.1",
 	ListenPort: 63636,
 	Web:        true,
 }
 
 // Options to customize behavior
 type Options struct {
+	ListenHost string
 	ListenPort int
 	Web        bool
 }


### PR DESCRIPTION
Closes [#95](https://github.com/projectdiscovery/clistats/issues/95)

• Added ListenHost to Options and DefaultOptions, and used it when starting the metrics server and building /metrics requests.

  This fixes the case where metrics were effectively tied to 127.0.0.1 and allows clistats to work on custom hosts such as 0.0.0.0.
