### PR TITLE
fix staticcheck QF1012 flagged by golangci-lint v9

### DIFF
--- a/clistats.go
+++ b/clistats.go
@@ -159,7 +159,7 @@ func (s *Statistics) metricsHandler(w http.ResponseWriter, req *http.Request) {
 	data, err := jsoniter.Marshal(items)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(fmt.Sprintf(`{"error":"%s"}`, err)))
+		_, _ = fmt.Fprintf(w, `{"error":"%s"}`, err)
 		return
 	}
 	_, _ = w.Write(data)


### PR DESCRIPTION
Replaces `Write([]byte(fmt.Sprintf(...)))` with `fmt.Fprintf` on `clistats.go:162`. Unblocks the golangci-lint-action v9 bump (#101) and downstream Dependabot PRs.