### PR TITLE
bump CI go-version to stable

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.21
+          go-version: stable
 
       - name: Check out code
         uses: actions/checkout@v6

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.21
+          go-version: stable
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9.2.0
         with:


### PR DESCRIPTION
Unblocks deps bumps that require a newer Go (e.g. utils 0.11.0 needs >= 1.24). Pinning to stable keeps us moving forward with releases.