### PR TITLE
fix: guard percent divide by zero

### DIFF
--- a/clistats.go
+++ b/clistats.go
@@ -151,8 +151,11 @@ func (s *Statistics) metricsHandler(w http.ResponseWriter, req *http.Request) {
 	}
 	// percent
 	if hasRequests && hasTotal {
-		percentData := (float64(requests) * float64(100)) / float64(total)
-		percent := String(uint64(percentData))
+		percent := String(uint64(0))
+		if total > 0 {
+			percentData := (float64(requests) * float64(100)) / float64(total)
+			percent = String(uint64(percentData))
+		}
 		items["percent"] = percent
 	}
 

--- a/clistats_test.go
+++ b/clistats_test.go
@@ -1,6 +1,9 @@
 package clistats
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -68,4 +71,21 @@ func TestStartMultipleTimesWithoutStopping(t *testing.T) {
 
 	err = client.Stop()
 	require.Nil(t, err)
+}
+
+func TestMetricsHandlerPercentWithZeroTotal(t *testing.T) {
+	client, err := New()
+	require.Nil(t, err)
+
+	client.AddCounter("requests", 100)
+	client.AddCounter("total", 0)
+	client.AddStatic("startedAt", time.Now())
+
+	recorder := httptest.NewRecorder()
+	client.metricsHandler(recorder, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	require.Equal(t, http.StatusOK, recorder.Code)
+
+	items := make(map[string]interface{})
+	require.Nil(t, json.Unmarshal(recorder.Body.Bytes(), &items))
+	require.Equal(t, "0", items["percent"])
 }


### PR DESCRIPTION
`/metrics` divided requests by a zero `total`, and `uint64(+Inf)` is arch dependent garbage (2^63 on amd64, 2^64-1 on arm64). Now emits `"0"` when `total` is 0, keeping the key present for consumers that read it unconditionally.

Fixes #115
Context: https://github.com/projectdiscovery/nuclei/issues/7722
